### PR TITLE
ECU-3136 Create installation script for the upgrade analyzer tool

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,40 @@
+filePath="dev/upgrades"
+fileName="analyzer.jar"
+
+function getLatestSnapshot {
+    owner="liferay-upgrades"
+    repository="upgrade-analyzer"
+    tag="v2.0.0"
+    snapshot="upgrade-analyzer-1.0-SNAPSHOT.jar"
+    
+    #create directory if not exists
+    cd ~ && mkdir -p $filePath && cd $filePath && 
+    curl -L \
+    -o $fileName \
+    https://github.com/$owner/$repository/releases/download/$tag/$snapshot
+}
+
+#$1=functionDeclaration
+#$2=functionBody
+function writeFunction {
+    echo "function $1 {"$'\n'"    $2"$'\n}'
+}
+
+function addAliasOnBashrcFile {
+    analyzerFunctionName="analyze_upgrade_project"
+
+    #only add alias and function if analyze_upgrade_project function is not present on bashrc file
+    if ! (grep -q $analyzerFunctionName ~/.bashrc); then  
+        analyzerFunctionBody="java -jar ~/$filePath/$fileName \"\$@\""
+        analyzerFunction=$(writeFunction "$analyzerFunctionName" "$analyzerFunctionBody")
+        
+        aliasFunctionBody="alias aup=\""$analyzerFunctionName"\""
+        aliasFunctionName=upgrade_analyzer_alias
+        aliasFunction=$(writeFunction "$aliasFunctionName" "$aliasFunctionBody")
+
+        echo $'\n\n'"$analyzerFunction"$'\n\n'"$aliasFunction"$'\n\n'"$aliasFunctionName">> ~/.bashrc 
+    fi
+}
+
+getLatestSnapshot
+addAliasOnBashrcFile


### PR DESCRIPTION
[ECU-3136](https://liferay.atlassian.net/browse/ECU-3136)

I had to change the visibility of the project to make it easier for people to install the tool, but it could be interesting to keep private and add an authorization in the curl.

For testing: 
`curl -o- https://raw.githubusercontent.com/liferay-upgrades/upgrade-analyzer/ECU-3136/install.sh | bash`

For use the alias:
`aup 'path to workspace'`

This url should be updated after the merge. Don't forget to update the readme :).
If it has an error, check if you are in java 11.

And now my watch is ended.

[ECU-3136]: https://liferay.atlassian.net/browse/ECU-3136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ